### PR TITLE
Fix tricky threading bug by changing order of operations.

### DIFF
--- a/src/zaffre/glterminal.clj
+++ b/src/zaffre/glterminal.clj
@@ -365,8 +365,8 @@
            (do
              (log/info "Destroying display")
              (with-gl-context gl-lock
-               (Display/destroy)
-               (reset! gl-lock false))
+               (reset! gl-lock false)
+               (Display/destroy))
              (log/info "Exiting"))
            (do
              (Thread/sleep 1)


### PR DESCRIPTION
For some reason I hit this problem *never* when running the examples directly in zaffre, and *always* when running my own project (game). I was getting exceptions like this:

```
Exception in thread "async-dispatch-1" java.lang.IllegalMonitorStateException
        at zaffre.glterminal$make_terminal$fn__8616$state_machine__5305__auto____8617$fn__8619$fn__8621$fn__8622.invoke(
glterminal.clj:915)
        at zaffre.glterminal$make_terminal$fn__8616$state_machine__5305__auto____8617$fn__8619$fn__8621.invoke(gltermina
l.clj:915)
        at zaffre.glterminal$make_terminal$fn__8616$state_machine__5305__auto____8617$fn__8619.invoke(glterminal.clj:914
)
        at zaffre.glterminal$make_terminal$fn__8616$state_machine__5305__auto____8617.invoke(glterminal.clj:914)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:1011)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:1015)
        at zaffre.glterminal$make_terminal$fn__8616.invoke(glterminal.clj:914)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

I believe this was due to the key-press routing goroutine trying to access the terminal after it was destroyed but before the gl-lock variable was reset to false. Switching the order has fixed this problem for me (I installed the modified version locally to test).

I think this fix makes sense logically: first you stop anyone from trying to access the terminal, then you actually destroy it.

Anyway, here's the fix.